### PR TITLE
improve error handling and request/response flow

### DIFF
--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -10,12 +10,14 @@ import Jimp from 'jimp'
 export async function filterImageFromURL(url: URL): Promise<ReadStream> {
     return new Promise(async (resolve, reject) => {
         const image: any = await Jimp.read(url.href).catch((error) => reject(`${error}`))
-        const path = `tmp/filtered.${Math.floor(Math.random() * Date.now())}.jpg`
-        const fqpn = `${__dirname}/${path}`
         
         if (undefined === image) {
             return
         }
+
+        const ext = url.pathname.split('.').pop();
+        const path = `tmp/filtered.${Math.floor(Math.random() * Date.now())}.${ext}`
+        const fqpn = `${__dirname}/${path}`
         
         image.resize(256, 256)
             .quality(60)


### PR DESCRIPTION
### Summary

This intends to improve the error handling and _streamline_ (no pun intended) the code, while also making it more robust.

**Server**

* essentially only perform validation on input, and return early if anything invalid is encountered
    - subsequently hand input off to the filter utility and catch any errors emitted, responding with the results of the filter promise – at this point we don't care if it's an error or a content stream
* if `filterImageFromURL` is rejected, we will appropriately set our response status to `400`

**Filter**

* now resolves a stream instead of a string (the FQPN)
* will attempt to detect the file extension, instead of hard coding `.jpg`
